### PR TITLE
replace firstChild by firstElementChild in _clearPage

### DIFF
--- a/zero-list-hero.html
+++ b/zero-list-hero.html
@@ -210,7 +210,7 @@ SOFTWARE.
       },
       _clearPage: function (page) {
         var t = this.$[page];
-        while (Polymer.dom(t).firstChild) { Polymer.dom(t).removeChild(Polymer.dom(t).firstChild); }
+        while (Polymer.dom(t).firstElementChild) { Polymer.dom(t).removeChild(Polymer.dom(t).firstElementChild); }
       },
       _clonePage: function (nodes, page) {
         this._placed = [];


### PR DESCRIPTION
master generates uncaught error when `firstChild` is a text node in _clearPage.

```
Uncaught Error: The node to be removed is not a child of this node: [object Text]
```
